### PR TITLE
refactor: move health check endpoint 

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,13 +80,6 @@ func init() {
 func main() {
 	router := gin.Default()
 
-	// Health check endpoint
-	router.GET("/healthz", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{
-			"status": "healthy",
-		})
-	})
-
 	// Proxy routes
 	if ProxyMode == "azure" {
 		router.GET("/v1/models", handleGetModels)
@@ -121,6 +114,13 @@ func main() {
 	} else {
 		router.Any("*path", handleOpenAIProxy)
 	}
+
+	// Health check endpoint
+	router.GET("/healthz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status": "healthy",
+		})
+	})
 
 	router.Run(Address)
 }


### PR DESCRIPTION
to a more appropriate location in main.go to prevent gin wildcard handing in openai mode